### PR TITLE
Skip yarn install when lockfile is missing during Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,12 +53,11 @@ RUN bundle install && \
     # -j 1 disable parallel compilation to avoid a QEMU bug: https://github.com/rails/bootsnap/issues/495
     bundle exec bootsnap precompile -j 1 --gemfile
 
-# Install node modules
-COPY package.json yarn.lock ./
-RUN yarn install --immutable
-
 # Copy application code
 COPY . .
+
+# Install node modules when package metadata is present
+RUN if [ -f package.json ] && [ -f yarn.lock ]; then yarn install --immutable; fi
 
 # Precompile bootsnap code for faster boot times.
 # -j 1 disable parallel compilation to avoid a QEMU bug: https://github.com/rails/bootsnap/issues/495


### PR DESCRIPTION
### Motivation
- Avoid Docker build failures on platforms like Fly when `yarn.lock` (or `package.json`) is absent by making the node install step optional and copying the full source before installing node modules.

### Description
- Updated `Dockerfile` to `COPY . .` earlier and replace the unconditional `COPY package.json yarn.lock` + `yarn install --immutable` with a conditional `RUN if [ -f package.json ] && [ -f yarn.lock ]; then yarn install --immutable; fi`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f4a11cdc083339cf625a35f0572af)