### PR TITLE
Bind Puma to 0.0.0.0 for Fly proxy routing

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -31,6 +31,9 @@ threads threads_count, threads_count
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 port ENV.fetch("PORT", 3000)
 
+# Bind to all interfaces so Fly can reach the app via its proxy.
+bind "tcp://0.0.0.0:#{ENV.fetch("PORT", 3000)}"
+
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
 


### PR DESCRIPTION
### Motivation
- Fly's proxy requires the application to listen on all interfaces and the configured port so it can route traffic, and Puma was only configured with `port`, making the app unreachable by the Fly proxy.

### Description
- Updated `config/puma.rb` to add `bind "tcp://0.0.0.0:#{ENV.fetch("PORT", 3000)}"` so Puma binds to all interfaces using the configured `PORT`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f6e7d87e883338d0f4ce54c606783)