### PR TITLE
Style Devise login and sign-up inputs

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,0 +1,37 @@
+<div class="max-w-md mx-auto">
+  <div class="bg-gray-800 rounded-lg p-8 border border-gray-700">
+    <h1 class="text-3xl font-bold mb-6">Sign Up</h1>
+
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), class: "space-y-6") do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
+
+      <div>
+        <%= f.label :email, class: "block text-sm font-semibold mb-2" %>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email",
+            class: "w-full bg-gray-900 border border-gray-600 rounded-lg px-4 py-3 focus:border-purple-500 focus:ring-1 focus:ring-purple-500" %>
+      </div>
+
+      <div>
+        <%= f.label :password, class: "block text-sm font-semibold mb-2" %>
+        <%= f.password_field :password, autocomplete: "new-password",
+            class: "w-full bg-gray-900 border border-gray-600 rounded-lg px-4 py-3 focus:border-purple-500 focus:ring-1 focus:ring-purple-500" %>
+        <% if @minimum_password_length %>
+          <p class="text-sm text-gray-400 mt-2">
+            <%= @minimum_password_length %> characters minimum
+          </p>
+        <% end %>
+      </div>
+
+      <div>
+        <%= f.label :password_confirmation, class: "block text-sm font-semibold mb-2" %>
+        <%= f.password_field :password_confirmation, autocomplete: "new-password",
+            class: "w-full bg-gray-900 border border-gray-600 rounded-lg px-4 py-3 focus:border-purple-500 focus:ring-1 focus:ring-purple-500" %>
+      </div>
+
+      <div class="flex items-center justify-between">
+        <%= f.submit "Create Account", class: "bg-purple-600 hover:bg-purple-700 text-white px-6 py-3 rounded-lg font-semibold cursor-pointer" %>
+        <%= link_to "Already have an account?", new_session_path(resource_name), class: "text-sm text-purple-400 hover:text-purple-300" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,0 +1,31 @@
+<div class="max-w-md mx-auto">
+  <div class="bg-gray-800 rounded-lg p-8 border border-gray-700">
+    <h1 class="text-3xl font-bold mb-6">Log In</h1>
+
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name), class: "space-y-6") do |f| %>
+      <div>
+        <%= f.label :email, class: "block text-sm font-semibold mb-2" %>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email",
+            class: "w-full bg-gray-900 border border-gray-600 rounded-lg px-4 py-3 focus:border-purple-500 focus:ring-1 focus:ring-purple-500" %>
+      </div>
+
+      <div>
+        <%= f.label :password, class: "block text-sm font-semibold mb-2" %>
+        <%= f.password_field :password, autocomplete: "current-password",
+            class: "w-full bg-gray-900 border border-gray-600 rounded-lg px-4 py-3 focus:border-purple-500 focus:ring-1 focus:ring-purple-500" %>
+      </div>
+
+      <% if devise_mapping.rememberable? %>
+        <div class="flex items-center">
+          <%= f.check_box :remember_me, class: "h-4 w-4 text-purple-600 bg-gray-900 border-gray-600 rounded" %>
+          <%= f.label :remember_me, class: "ml-2 text-sm text-gray-300" %>
+        </div>
+      <% end %>
+
+      <div class="flex items-center justify-between">
+        <%= f.submit "Log In", class: "bg-purple-600 hover:bg-purple-700 text-white px-6 py-3 rounded-lg font-semibold cursor-pointer" %>
+        <%= link_to "Create an account", new_registration_path(resource_name), class: "text-sm text-purple-400 hover:text-purple-300" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,0 +1,12 @@
+<% if resource.errors.any? %>
+  <div class="bg-red-500/10 border border-red-500 rounded-lg p-4">
+    <h2 class="font-semibold text-red-400 mb-2">
+      <%= pluralize(resource.errors.count, "error") %> prevented this account from being saved:
+    </h2>
+    <ul class="list-disc list-inside text-red-300">
+      <% resource.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>


### PR DESCRIPTION
### Motivation
- Make the Devise login and sign-up forms visually consistent with the rest of the site by applying the same Tailwind-based input styles and container layout.
- Surface validation errors in a consistent alert style so account errors match other form error displays.
- Ensure the sign-in and sign-up flows include the same CTA/link styling and remember-me checkbox presentation as other pages.

### Description
- Add a custom Devise sign-in view at `app/views/devise/sessions/new.html.erb` with styled `email` and `password` fields and a styled submit button and link to registration.
- Add a custom Devise registration view at `app/views/devise/registrations/new.html.erb` with styled `email`, `password`, and `password_confirmation` fields, password-length hint, and a styled submit button and link to sign-in.
- Add a shared Devise error partial at `app/views/devise/shared/_error_messages.html.erb` that renders validation errors using the same alert/card styling used elsewhere.

### Testing
- Attempted to boot the Rails server with `bin/rails server -p 3000 -b 0.0.0.0` to manually verify the views, but the run failed due to missing gems so the app could not be started.
- No automated tests were executed as dependencies are not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697334f73e088333920dbec62396da9d)