### PR TITLE
Add display_name to Devise sign-up

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ class ApplicationController < ActionController::Base
   allow_browser versions: :modern
 
   before_action :authenticate_user!, unless: :devise_controller?
+  before_action :configure_permitted_parameters, if: :devise_controller?
 
   private
 
@@ -19,5 +20,10 @@ class ApplicationController < ActionController::Base
     unless membership&.admin?
       redirect_to root_path, alert: "You must be an admin of this group to perform this action."
     end
+  end
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:display_name])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:display_name])
   end
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -12,6 +12,12 @@
       </div>
 
       <div>
+        <%= f.label :display_name, "Display name", class: "block text-sm font-semibold mb-2" %>
+        <%= f.text_field :display_name, autocomplete: "name",
+            class: "w-full bg-gray-900 border border-gray-600 rounded-lg px-4 py-3 focus:border-purple-500 focus:ring-1 focus:ring-purple-500" %>
+      </div>
+
+      <div>
         <%= f.label :password, class: "block text-sm font-semibold mb-2" %>
         <%= f.password_field :password, autocomplete: "new-password",
             class: "w-full bg-gray-900 border border-gray-600 rounded-lg px-4 py-3 focus:border-purple-500 focus:ring-1 focus:ring-purple-500" %>


### PR DESCRIPTION
### Motivation
- The `User` model requires `display_name` (`validates :display_name, presence: true`) but the Devise registration flow did not permit or collect this attribute, causing sign-up to fail with a "Display name can't be blank" error.

### Description
- Add `before_action :configure_permitted_parameters, if: :devise_controller?` to `ApplicationController` to enable custom Devise parameter handling.
- Implement `configure_permitted_parameters` to permit `:display_name` for `:sign_up` and `:account_update` using `devise_parameter_sanitizer`.
- Add a `display_name` text input to the sign-up form in `app/views/devise/registrations/new.html.erb` so users can provide the required value at registration.

### Testing
- Attempted to start the Rails server with `bin/rails server -p 3000` but it failed due to missing gems so runtime/automated tests could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69733789fbfc83338df6df55df9d445f)