### PR TITLE
Implement point-based voting limits and editable week deadlines

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -53,6 +53,6 @@ class GroupsController < ApplicationController
   end
 
   def group_params
-    params.require(:group).permit(:name)
+    params.require(:group).permit(:name, :max_points_per_song)
   end
 end

--- a/app/controllers/leaderboards_controller.rb
+++ b/app/controllers/leaderboards_controller.rb
@@ -11,10 +11,9 @@ class LeaderboardsController < ApplicationController
       {
         submission: submission,
         user: submission.user,
-        average_score: submission.votes.average(:score)&.round(2) || 0,
-        vote_count: submission.votes.count
+        total_points: submission.votes.sum(:score)
       }
-    end.sort_by { |r| -r[:average_score] }
+    end.sort_by { |r| -r[:total_points] }
   end
 
   def season
@@ -33,8 +32,8 @@ class LeaderboardsController < ApplicationController
         average_score: 0
       }
 
-      avg_score = submission.votes.average(:score) || 0
-      user_stats[user_id][:total_score] += avg_score
+      points = submission.votes.sum(:score)
+      user_stats[user_id][:total_score] += points
       user_stats[user_id][:games_played] += 1
     end
 
@@ -61,8 +60,8 @@ class LeaderboardsController < ApplicationController
         seasons_played: Set.new
       }
 
-      avg_score = submission.votes.average(:score) || 0
-      user_stats[user_id][:total_score] += avg_score
+      points = submission.votes.sum(:score)
+      user_stats[user_id][:total_score] += points
       user_stats[user_id][:games_played] += 1
       user_stats[user_id][:seasons_played] << submission.week.season_id
     end

--- a/app/controllers/seasons_controller.rb
+++ b/app/controllers/seasons_controller.rb
@@ -24,8 +24,8 @@ class SeasonsController < ApplicationController
         average_score: 0
       }
 
-      avg_score = submission.votes.average(:score) || 0
-      user_stats[user_id][:total_score] += avg_score
+      points = submission.votes.sum(:score)
+      user_stats[user_id][:total_score] += points
       user_stats[user_id][:games_played] += 1
     end
 

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -14,7 +14,7 @@ class SubmissionsController < ApplicationController
     @season = @week.season
     @group = @season.group
     @votes = @submission.votes.includes(:voter)
-    @average_score = @votes.average(:score)&.round(2)
+    @total_points = @votes.sum(:score)
   end
 
   def new

--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -4,14 +4,23 @@ class VotesController < ApplicationController
   before_action :check_voting_phase
 
   def create
-    @vote = @submission.votes.build(vote_params)
-    @vote.voter = current_user
     @week = @submission.week
     @season = @week.season
     @group = @season.group
+    existing_vote = Vote.find_by(submission: @submission, voter: current_user)
+
+    if existing_vote
+      existing_vote.score += 1
+      @vote = existing_vote
+      success_message = "Point added!"
+    else
+      @vote = @submission.votes.build(vote_params.merge(score: 1))
+      @vote.voter = current_user
+      success_message = "Your vote has been recorded!"
+    end
 
     if @vote.save
-      redirect_to group_season_week_path(@group, @season, @week), notice: "Your vote has been recorded!"
+      redirect_to group_season_week_path(@group, @season, @week), notice: success_message
     else
       redirect_to group_season_week_path(@group, @season, @week),
                   alert: @vote.errors.full_messages.join(", ")
@@ -25,7 +34,7 @@ class VotesController < ApplicationController
   end
 
   def vote_params
-    params.require(:vote).permit(:score, :comment)
+    params.require(:vote).permit(:comment)
   end
 
   def require_group_membership
@@ -46,10 +55,14 @@ class VotesController < ApplicationController
       redirect_to group_season_week_path(@week.season.group, @week.season, @week),
                   alert: "You cannot vote on your own submission."
     end
-
-    if Vote.exists?(submission: @submission, voter: current_user)
+    if remaining_points_for_week <= 0
       redirect_to group_season_week_path(@week.season.group, @week.season, @week),
-                  alert: "You have already voted on this submission."
+                  alert: "You have already used all #{Week::TOTAL_POINTS_PER_USER} points for this week."
     end
+  end
+
+  def remaining_points_for_week
+    used_points = current_user.votes.joins(:submission).where(submissions: { week_id: @week.id }).sum(:score)
+    Week::TOTAL_POINTS_PER_USER - used_points
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -7,6 +7,11 @@ class Group < ApplicationRecord
   # Validations
   validates :name, presence: true
   validates :invite_code, uniqueness: true, allow_nil: true
+  validates :max_points_per_song, numericality: {
+    only_integer: true,
+    greater_than: 0,
+    less_than_or_equal_to: Week::TOTAL_POINTS_PER_USER
+  }
 
   # Token generation
   has_secure_token :invite_code

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -9,8 +9,8 @@ class Submission < ApplicationRecord
   validate :song_url_must_be_safe
 
   # Instance methods
-  def average_score
-    votes.average(:score)&.round(2) || 0
+  def total_points
+    votes.sum(:score)
   end
 
   private

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -3,15 +3,39 @@ class Vote < ApplicationRecord
   belongs_to :voter, class_name: "User"
 
   # Validations
-  validates :score, presence: true, inclusion: { in: 1..10 }
+  validates :score, presence: true, numericality: { only_integer: true, greater_than: 0 }
   validates :voter_id, uniqueness: { scope: :submission_id, message: "can only vote once per submission" }
   validate :cannot_vote_on_own_submission
+  validate :score_within_song_limit
+  validate :total_points_within_week
 
   private
 
   def cannot_vote_on_own_submission
     if submission && voter_id == submission.user_id
       errors.add(:voter, "cannot vote on own submission")
+    end
+  end
+
+  def score_within_song_limit
+    return unless submission && score
+
+    max_points = submission.week.season.group.max_points_per_song
+    if score > max_points
+      errors.add(:score, "cannot exceed #{max_points} points for a single song")
+    end
+  end
+
+  def total_points_within_week
+    return unless submission && voter && score
+
+    week = submission.week
+    other_votes_total = Vote.joins(:submission)
+                             .where(voter_id: voter_id, submissions: { week_id: week.id })
+                             .where.not(id: id)
+                             .sum(:score)
+    if other_votes_total + score > Week::TOTAL_POINTS_PER_USER
+      errors.add(:score, "cannot exceed #{Week::TOTAL_POINTS_PER_USER} total points for the week")
     end
   end
 end

--- a/app/models/week.rb
+++ b/app/models/week.rb
@@ -1,4 +1,6 @@
 class Week < ApplicationRecord
+  TOTAL_POINTS_PER_USER = 6
+
   belongs_to :season
   has_many :submissions, dependent: :destroy
 

--- a/app/services/scoring_service.rb
+++ b/app/services/scoring_service.rb
@@ -4,10 +4,7 @@ class ScoringService
     votes = submission.votes
     return 0 if votes.empty?
 
-    # Calculate average score
-    total = votes.sum(:score)
-    average = total.to_f / votes.count
-    average.round(2)
+    votes.sum(:score)
   end
 
   def self.calculate_weekly_scores(week)

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -30,6 +30,15 @@
         <%= f.text_field :name, class: "w-full bg-gray-900 border border-gray-600 rounded-lg px-4 py-3 focus:border-purple-500 focus:ring-1 focus:ring-purple-500" %>
       </div>
 
+      <div>
+        <%= f.label :max_points_per_song, "Max Points Per Song", class: "block text-sm font-semibold mb-2" %>
+        <%= f.number_field :max_points_per_song, min: 1, max: Week::TOTAL_POINTS_PER_USER,
+            class: "w-full bg-gray-900 border border-gray-600 rounded-lg px-4 py-3 focus:border-purple-500 focus:ring-1 focus:ring-purple-500" %>
+        <p class="text-sm text-gray-400 mt-2">
+          Each member gets <%= Week::TOTAL_POINTS_PER_USER %> points per week to distribute.
+        </p>
+      </div>
+
       <div class="flex items-center justify-between pt-4">
         <%= f.submit "Update Group", class: "bg-purple-600 hover:bg-purple-700 text-white px-8 py-3 rounded-lg font-semibold cursor-pointer" %>
         <%= link_to "Cancel", @group, class: "text-gray-400 hover:text-white" %>

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -30,6 +30,15 @@
         <%= f.text_field :name, class: "w-full bg-gray-900 border border-gray-600 rounded-lg px-4 py-3 focus:border-purple-500 focus:ring-1 focus:ring-purple-500", placeholder: "My Music Group" %>
       </div>
 
+      <div>
+        <%= f.label :max_points_per_song, "Max Points Per Song", class: "block text-sm font-semibold mb-2" %>
+        <%= f.number_field :max_points_per_song, min: 1, max: Week::TOTAL_POINTS_PER_USER,
+            class: "w-full bg-gray-900 border border-gray-600 rounded-lg px-4 py-3 focus:border-purple-500 focus:ring-1 focus:ring-purple-500" %>
+        <p class="text-sm text-gray-400 mt-2">
+          Each member gets <%= Week::TOTAL_POINTS_PER_USER %> points per week to distribute.
+        </p>
+      </div>
+
       <div class="flex items-center justify-between pt-4">
         <%= f.submit "Create Group", class: "bg-purple-600 hover:bg-purple-700 text-white px-8 py-3 rounded-lg font-semibold cursor-pointer" %>
         <%= link_to "Cancel", groups_path, class: "text-gray-400 hover:text-white" %>

--- a/app/views/leaderboards/all_time.html.erb
+++ b/app/views/leaderboards/all_time.html.erb
@@ -29,7 +29,7 @@
                 <div class="text-sm text-gray-400">
                   <p><%= pluralize(ranking[:games_played], "game") %></p>
                   <p><%= pluralize(ranking[:seasons_played], "season") %></p>
-                  <p>Avg: <%= ranking[:average_score] %></p>
+                  <p>Avg points: <%= ranking[:average_score] %></p>
                 </div>
               </div>
             </div>
@@ -60,7 +60,7 @@
                   <p class="text-sm text-gray-400">
                     <%= pluralize(ranking[:games_played], "game") %> • 
                     <%= pluralize(ranking[:seasons_played], "season") %> • 
-                    <%= ranking[:average_score] %> avg
+                    <%= ranking[:average_score] %> avg points
                   </p>
                 </div>
               </div>

--- a/app/views/leaderboards/season.html.erb
+++ b/app/views/leaderboards/season.html.erb
@@ -27,7 +27,7 @@
                 </p>
                 <div class="text-sm text-gray-400">
                   <p><%= pluralize(ranking[:games_played], "game") %></p>
-                  <p>Avg: <%= ranking[:average_score] %></p>
+                  <p>Avg points: <%= ranking[:average_score] %></p>
                 </div>
               </div>
             </div>
@@ -57,7 +57,7 @@
                   <p class="font-bold text-lg"><%= ranking[:user].display_name %></p>
                   <p class="text-sm text-gray-400">
                     <%= pluralize(ranking[:games_played], "game") %> played • 
-                    <%= ranking[:average_score] %> avg
+                    <%= ranking[:average_score] %> avg points
                   </p>
                 </div>
               </div>

--- a/app/views/leaderboards/weekly.html.erb
+++ b/app/views/leaderboards/weekly.html.erb
@@ -24,10 +24,10 @@
                 </div>
                 <p class="font-bold text-lg mb-1"><%= ranking[:user].display_name %></p>
                 <p class="text-3xl font-bold text-purple-400 mb-1">
-                  <%= ranking[:average_score] %>
+                  <%= ranking[:total_points] %>
                 </p>
                 <p class="text-sm text-gray-400">
-                  <%= pluralize(ranking[:vote_count], "vote") %>
+                  <%= pluralize(ranking[:total_points], "point") %>
                 </p>
               </div>
             </div>
@@ -60,8 +60,8 @@
                 </div>
               </div>
               <div class="text-right">
-                <p class="text-3xl font-bold text-purple-400"><%= ranking[:average_score] %></p>
-                <p class="text-xs text-gray-400"><%= pluralize(ranking[:vote_count], "vote") %></p>
+                <p class="text-3xl font-bold text-purple-400"><%= ranking[:total_points] %></p>
+                <p class="text-xs text-gray-400"><%= pluralize(ranking[:total_points], "point") %></p>
               </div>
             </div>
           </div>

--- a/app/views/weeks/edit.html.erb
+++ b/app/views/weeks/edit.html.erb
@@ -9,7 +9,7 @@
   </div>
 
   <div class="bg-gray-800 rounded-lg p-8 border border-gray-700">
-    <h1 class="text-3xl font-bold mb-8">Edit Week <%= @week.number %> Category</h1>
+    <h1 class="text-3xl font-bold mb-8">Edit Week <%= @week.number %></h1>
 
     <%= form_with model: @week, url: group_season_week_path(@group, @season, @week), method: :patch, class: "space-y-6" do |f| %>
       <% if @week.errors.any? %>
@@ -34,8 +34,20 @@
         </p>
       </div>
 
+      <div>
+        <%= f.label :submission_deadline, "Submission Deadline", class: "block text-sm font-semibold mb-2" %>
+        <%= f.datetime_field :submission_deadline,
+            class: "w-full bg-gray-900 border border-gray-600 rounded-lg px-4 py-3 focus:border-purple-500 focus:ring-1 focus:ring-purple-500" %>
+      </div>
+
+      <div>
+        <%= f.label :voting_deadline, "Voting Deadline", class: "block text-sm font-semibold mb-2" %>
+        <%= f.datetime_field :voting_deadline,
+            class: "w-full bg-gray-900 border border-gray-600 rounded-lg px-4 py-3 focus:border-purple-500 focus:ring-1 focus:ring-purple-500" %>
+      </div>
+
       <div class="flex items-center justify-between pt-4">
-        <%= f.submit "Update Category", class: "bg-purple-600 hover:bg-purple-700 text-white px-8 py-3 rounded-lg font-semibold cursor-pointer" %>
+        <%= f.submit "Update Week", class: "bg-purple-600 hover:bg-purple-700 text-white px-8 py-3 rounded-lg font-semibold cursor-pointer" %>
         <%= link_to "Cancel", group_season_week_path(@group, @season, @week), class: "text-gray-400 hover:text-white" %>
       </div>
     <% end %>

--- a/app/views/weeks/show.html.erb
+++ b/app/views/weeks/show.html.erb
@@ -45,7 +45,7 @@
 
     <% if @group.memberships.find_by(user: current_user).admin? %>
       <div class="mt-4 pt-4 border-t border-gray-700">
-        <%= link_to "Edit Category", edit_group_season_week_path(@group, @season, @week), 
+        <%= link_to "Edit Week", edit_group_season_week_path(@group, @season, @week), 
             class: "text-purple-400 hover:text-purple-300 text-sm underline" %>
       </div>
     <% end %>
@@ -102,10 +102,26 @@
         <p class="text-gray-400 mb-4">
           Time remaining: <%= distance_of_time_in_words(Time.current, @week.voting_deadline) %>
         </p>
+        <div class="bg-gray-900 border border-gray-700 rounded-lg p-4 mb-4 text-sm text-gray-300">
+          <p class="font-semibold text-purple-300 mb-1">
+            Points remaining: <%= @remaining_points %> / <%= Week::TOTAL_POINTS_PER_USER %>
+          </p>
+          <p>
+            You can give up to <%= @group.max_points_per_song %> points per song.
+          </p>
+          <% if @remaining_points.zero? %>
+            <p class="text-green-400 mt-2">
+              You've submitted all your points and can no longer vote or comment this week.
+            </p>
+          <% end %>
+        </div>
 
         <% if @submissions_to_vote.any? %>
           <div class="space-y-4">
             <% @submissions_to_vote.each do |submission| %>
+              <% user_vote = @user_votes[submission.id] %>
+              <% points_for_song = user_vote&.score.to_i %>
+              <% can_add_point = @remaining_points.positive? && points_for_song < @group.max_points_per_song %>
               <div class="bg-gray-900 rounded-lg p-4 border border-gray-700">
                 <div class="mb-4">
                   <p class="text-lg font-semibold mb-1"><%= submission.song_title %></p>
@@ -126,19 +142,33 @@
                     <% end %>
                 </div>
 
-                <%= form_with url: submission_votes_path(submission), method: :post, class: "space-y-3" do |f| %>
-                  <div>
-                    <%= f.label :score, "Your Score (1-10)", class: "block text-sm font-semibold mb-2" %>
-                    <%= f.number_field :score, min: 1, max: 10, required: true,
-                        class: "w-full bg-gray-800 border border-gray-600 rounded px-4 py-2" %>
-                  </div>
-                  <div>
-                    <%= f.label :comment, "Comment (optional)", class: "block text-sm font-semibold mb-2" %>
-                    <%= f.text_area :comment, rows: 2,
-                        class: "w-full bg-gray-800 border border-gray-600 rounded px-4 py-2", 
-                        placeholder: "Share your thoughts..." %>
-                  </div>
-                  <%= f.submit "Submit Vote", class: "w-full bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded font-semibold cursor-pointer" %>
+                <div class="flex items-center justify-between text-sm text-gray-300 mb-3">
+                  <span>Your points: <%= points_for_song %> / <%= @group.max_points_per_song %></span>
+                  <% if @remaining_points.zero? %>
+                    <span class="text-green-400">All points submitted for the week.</span>
+                  <% end %>
+                </div>
+
+                <% if can_add_point %>
+                  <%= form_with url: submission_votes_path(submission), method: :post, class: "space-y-3" do |f| %>
+                    <% if user_vote.nil? %>
+                      <div>
+                        <%= f.label :comment, "Comment (optional)", class: "block text-sm font-semibold mb-2" %>
+                        <%= f.text_area :comment, rows: 2,
+                            class: "w-full bg-gray-800 border border-gray-600 rounded px-4 py-2",
+                            placeholder: "Share your thoughts..." %>
+                      </div>
+                    <% end %>
+                    <%= f.submit "+1 Point", class: "w-full bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded font-semibold cursor-pointer" %>
+                  <% end %>
+                <% else %>
+                  <p class="text-sm text-gray-500 italic">
+                    <% if points_for_song >= @group.max_points_per_song %>
+                      You've reached the max points for this song.
+                    <% elsif @remaining_points.zero? %>
+                      You've submitted all points for the week.
+                    <% end %>
+                  </p>
                 <% end %>
               </div>
             <% end %>
@@ -146,7 +176,7 @@
         <% else %>
           <div class="bg-green-500/10 border border-green-500 rounded-lg p-4">
             <p class="text-green-400 text-center">
-              ✓ You've voted on all submissions! Check back after the voting deadline for results.
+              ✓ No submissions to vote on yet. Check back after the submission deadline.
             </p>
           </div>
         <% end %>
@@ -166,7 +196,7 @@
 
         <% if @submissions.any? %>
           <div class="space-y-4">
-            <% @submissions.sort_by { |s| -(s.votes.average(:score) || 0) }.each_with_index do |submission, index| %>
+            <% @submissions.sort_by { |s| -s.total_points }.each_with_index do |submission, index| %>
               <div class="bg-gray-900 rounded-lg p-4 border <%= index == 0 ? 'border-yellow-500' : 'border-gray-700' %>">
                 <div class="flex items-start justify-between">
                   <div class="flex-1">
@@ -202,10 +232,10 @@
                   </div>
                   <div class="text-right ml-4">
                     <p class="text-3xl font-bold text-purple-400">
-                      <%= (submission.votes.average(:score) || 0).round(2) %>
+                      <%= submission.total_points %>
                     </p>
                     <p class="text-xs text-gray-400">
-                      <%= pluralize(submission.votes.count, "vote") %>
+                      <%= pluralize(submission.votes.sum(:score), "point") %>
                     </p>
                   </div>
                 </div>
@@ -213,12 +243,12 @@
                 <%# Show votes/comments %>
                 <% if submission.votes.any? %>
                   <div class="mt-4 pt-4 border-t border-gray-800">
-                    <p class="text-sm font-semibold mb-2 text-gray-400">Votes:</p>
+                    <p class="text-sm font-semibold mb-2 text-gray-400">Points:</p>
                     <div class="space-y-2">
                       <% submission.votes.includes(:voter).each do |vote| %>
                         <div class="text-sm bg-gray-800 p-2 rounded">
                           <span class="font-semibold"><%= vote.voter.display_name %>:</span>
-                          <span class="text-purple-400"><%= vote.score %>/10</span>
+                          <span class="text-purple-400"><%= pluralize(vote.score, "point") %></span>
                           <% if vote.comment.present? %>
                             <p class="text-gray-400 mt-1 italic">"<%= vote.comment %>"</p>
                           <% end %>

--- a/db/migrate/20260120000000_add_max_points_per_song_to_groups.rb
+++ b/db/migrate/20260120000000_add_max_points_per_song_to_groups.rb
@@ -1,0 +1,5 @@
+class AddMaxPointsPerSongToGroups < ActiveRecord::Migration[8.1]
+  def change
+    add_column :groups, :max_points_per_song, :integer, null: false, default: 3
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_19_153758) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_20_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -18,6 +18,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_19_153758) do
     t.datetime "created_at", null: false
     t.bigint "creator_id", null: false
     t.string "invite_code"
+    t.integer "max_points_per_song", default: 3, null: false
     t.string "name", null: false
     t.datetime "updated_at", null: false
     t.index ["creator_id"], name: "index_groups_on_creator_id"


### PR DESCRIPTION
### Motivation

- Replace numeric 1–10 scoring with a point-allocation system where each user has a fixed weekly budget and each song has a configurable per-song cap. 
- Enforce voting rules server-side to prevent users from exceeding weekly totals or per-song caps and to stop additional voting/comments after points are exhausted. 
- Let group admins set per-song caps and edit week submission/voting deadlines so scheduling is configurable.

### Description

- Added `Week::TOTAL_POINTS_PER_USER = 6` and migrated the app to score by total points rather than average scores across many controllers, views, and the `ScoringService`.
- Added `max_points_per_song` on `Group` (migration `db/migrate/20260120000000_add_max_points_per_song_to_groups.rb` and `db/schema.rb`) with model validation that caps it at `Week::TOTAL_POINTS_PER_USER` and exposed the field in group `new`/`edit` forms and `GroupsController#group_params`.
- Updated `Vote` model validations to require integer `score > 0`, enforce per-song limit (`score_within_song_limit`) and enforce weekly total cap (`total_points_within_week`), while keeping uniqueness of `(submission_id, voter_id)` so votes are stored as one record per voter+submission.
- Changed the voting workflow in `VotesController#create` to allocate points incrementally: if the voter already has a `Vote` for that submission we increment its `score` by 1, otherwise we create a new vote with `score = 1`; removed free-form numeric score input in favor of a `+1` action and preserved one-time comment capture on the first point for a submission.
- Updated `WeeksController#show` and views (`app/views/weeks/show.html.erb`, leaderboard views) to show remaining points, per-song points, and to display totals (total points per submission and per-user season/all-time totals) instead of averages; added UI messaging when a user has used all weekly points and limited commenting to first allocation.
- Made week deadlines editable by admins: added `submission_deadline` and `voting_deadline` to `week_params` and updated the `weeks#edit` form to allow changing these fields.
- Adjusted scoreboard/leaderboard logic to use sum of votes (`votes.sum(:score)`) across `LeaderboardsController`, `SeasonsController`, `ScoringService`, and templates to reflect the new points system.

### Testing

- Attempted to run `bundle install` but it failed due to network/Gem fetch errors (Rubygems returned HTTP 403), so gems could not be installed and full test/run could not be executed. (Result: failed — `Net::HTTPClientException 403 Forbidden`.)
- Attempted `bundle exec rails db:migrate`, but the `rails` executable was not available in the environment before `bundle install` completed, so migrations were not executed here (Result: failed — `bundler: command not found: rails`).
- Confirmed via staged changes and a local commit that code changes and the migration file were added successfully (commit message: "Adjust voting points and week settings").

Notes: All changes are implemented in code and committed, but database migrations were added but not applied in this environment due to dependency installation failures; please run `bundle install` and `bin/rails db:migrate` in your environment and run your test suite to fully validate runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69733a2a37588333ae68596554e82da0)