### PR TITLE
Scope vote form to `:vote` and tolerate missing vote params

### DIFF
--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -34,7 +34,7 @@ class VotesController < ApplicationController
   end
 
   def vote_params
-    params.require(:vote).permit(:comment)
+    params.fetch(:vote, {}).permit(:comment)
   end
 
   def require_group_membership

--- a/app/views/weeks/show.html.erb
+++ b/app/views/weeks/show.html.erb
@@ -150,7 +150,7 @@
                 </div>
 
                 <% if can_add_point %>
-                  <%= form_with url: submission_votes_path(submission), method: :post, class: "space-y-3" do |f| %>
+                  <%= form_with url: submission_votes_path(submission), method: :post, scope: :vote, class: "space-y-3" do |f| %>
                     <% if user_vote.nil? %>
                       <div>
                         <%= f.label :comment, "Comment (optional)", class: "block text-sm font-semibold mb-2" %>


### PR DESCRIPTION
### Motivation
- Ensure the comment input for vote forms is submitted under the `vote` key so `VotesController#vote_params` receives the expected params and to avoid `ParameterMissing` for empty comments.

### Description
- Updated the vote form in `app/views/weeks/show.html.erb` to `form_with ... scope: :vote` so inputs render as `vote[comment]`.
- Hardened `app/controllers/votes_controller.rb` by changing `params.require(:vote).permit(:comment)` to `params.fetch(:vote, {}).permit(:comment)` to accept missing/empty `vote` params.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974c1d490ac8333b1f9054f9ca8a86c)