### PR TITLE
Use user-specific Tidal playlists for submissions

### DIFF
--- a/app/jobs/generate_playlists_job.rb
+++ b/app/jobs/generate_playlists_job.rb
@@ -6,8 +6,11 @@ class GeneratePlaylistsJob < ApplicationJob
     user = User.find(user_id)
     submissions = week.submissions.includes(:user)
 
-    existing_playlist = UserPlaylist.find_by(user: user, name: week.category)
+    existing_playlist = UserPlaylist.find_by(user: user, week: week)
     return existing_playlist.tidal_url if existing_playlist
+
+    legacy_playlist = UserPlaylist.find_by(user: user, name: week.category)
+    return legacy_playlist.tidal_url if legacy_playlist
 
     return if submissions.empty?
 

--- a/app/views/weeks/show.html.erb
+++ b/app/views/weeks/show.html.erb
@@ -115,11 +115,6 @@
            data-vote-points-max-per-song-value="<%= @group.max_points_per_song %>">
         <div class="flex flex-wrap items-center justify-between gap-4 mb-4">
           <h2 class="text-xl font-semibold">Vote on Submissions</h2>
-          <%= button_to "Create Playlist",
-                        generate_playlist_group_season_week_path(@group, @season, @week),
-                        method: :post,
-                        form: { data: { turbo: false } },
-                        class: "bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded-lg text-sm font-semibold" %>
         </div>
         <p class="text-gray-400 mb-4">
           Time remaining: <%= distance_of_time_in_words(Time.current, @week.voting_deadline) %>
@@ -136,8 +131,8 @@
           </p>
         </div>
 
-        <% if @week.tidal_playlist_url.present? %>
-          <% if (playlist_src = tidal_playlist_embed_src(@week.tidal_playlist_url)) %>
+        <% if @user_tidal_playlist_url.present? %>
+          <% if (playlist_src = tidal_playlist_embed_src(@user_tidal_playlist_url)) %>
             <div class="mb-4" data-controller="toggle">
               <button type="button"
                       class="w-full bg-gray-900 border border-gray-700 rounded-lg px-4 py-2 text-sm font-semibold text-purple-300 hover:text-purple-200 hover:border-purple-400"
@@ -257,8 +252,8 @@
               class: "text-purple-400 hover:text-purple-300 text-sm" %>
         </div>
 
-        <% if @week.tidal_playlist_url.present? %>
-          <% if (playlist_src = tidal_playlist_embed_src(@week.tidal_playlist_url)) %>
+        <% if @user_tidal_playlist_url.present? %>
+          <% if (playlist_src = tidal_playlist_embed_src(@user_tidal_playlist_url)) %>
             <div class="mb-6" data-controller="toggle">
               <button type="button"
                       class="w-full bg-gray-900 border border-gray-700 rounded-lg px-4 py-2 text-sm font-semibold text-purple-300 hover:text-purple-200 hover:border-purple-400"


### PR DESCRIPTION
### Motivation
- The "Play submissions" UI should play the current user's Tidal playlist for the week using their Tidal connection and create the playlist if it doesn't already exist.
- Prefer week-scoped user playlists while keeping a legacy fallback for playlists previously stored by name.

### Description
- Add `ensure_user_tidal_playlist_url` to `WeeksController` and set `@user_tidal_playlist_url` during the voting and results phases to fetch or generate the current user's playlist.  
- Update `GeneratePlaylistsJob` to prefer `UserPlaylist.find_by(user: user, week: week)` and fall back to the legacy `name: week.category` lookup before creating a new playlist.  
- Change `app/views/weeks/show.html.erb` to embed the playlist using `@user_tidal_playlist_url` (via `tidal_playlist_embed_src`) in the "Play submissions" panels and remove the extra "Create Playlist" button from the voting UI.  

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69770bdd08548333a20a83d4af692ab3)